### PR TITLE
Fix invalid reporting during block return

### DIFF
--- a/lib/yardcheck/method_call.rb
+++ b/lib/yardcheck/method_call.rb
@@ -10,7 +10,8 @@ module Yardcheck
       :example_location,
       :return_value,
       :error_raised,
-      :in_ambiguous_raise
+      :in_ambiguous_raise,
+      :in_ambiguous_block_return
     )
 
     def self.process(params:, return_value:, **attributes)
@@ -24,8 +25,8 @@ module Yardcheck
       new(params: params, return_value: return_value, **attributes)
     end
 
-    def maybe_inside_exception_raise?
-      in_ambiguous_raise
+    def ambiguous_return_state?
+      in_ambiguous_raise || in_ambiguous_block_return
     end
 
     def method_identifier

--- a/lib/yardcheck/observation.rb
+++ b/lib/yardcheck/observation.rb
@@ -68,7 +68,7 @@ module Yardcheck
         !event.raised? &&
         !event.initialize? &&
         !documentation.predicate_method? &&
-        !event.maybe_inside_exception_raise?
+        !event.ambiguous_return_state?
     end
   end # Observation
 end # Yardcheck

--- a/spec/integration/yardcheck_spec.rb
+++ b/spec/integration/yardcheck_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe 'test app integration' do
   end
 
   it 'generates a warning for invalid constant' do
-    expect_report('WARNING: Unabled to resolve "What" for lib/test_app.rb:41')
-    expect_report('WARNING: Unabled to resolve "Wow" for lib/test_app.rb:41')
-    expect_report('WARNING: Unabled to resolve (Unspecified type) for lib/test_app.rb:56')
-    expect_report('WARNING: Unabled to resolve (Unspecified type) for lib/test_app.rb:56')
-    expect_report('WARNING: Unabled to resolve :foo for lib/test_app.rb:114')
+    expect_report('WARNING: Unabled to resolve "What" for lib/test_app.rb:42')
+    expect_report('WARNING: Unabled to resolve "Wow" for lib/test_app.rb:42')
+    expect_report('WARNING: Unabled to resolve (Unspecified type) for lib/test_app.rb:57')
+    expect_report('WARNING: Unabled to resolve (Unspecified type) for lib/test_app.rb:57')
+    expect_report('WARNING: Unabled to resolve :foo for lib/test_app.rb:115')
   end
 
   it 'reports expectations' do

--- a/spec/unit/yardcheck/method_tracer_spec.rb
+++ b/spec/unit/yardcheck/method_tracer_spec.rb
@@ -37,24 +37,26 @@ RSpec.describe Yardcheck::MethodTracer do
 
     expect(tracer.events).to eq([
       Yardcheck::MethodCall.process(
-        scope:              :class,
-        selector:           :singleton_method_example,
-        namespace:          Foo.singleton_class,
-        params:             { baz: 'Hello' },
-        return_value:       'HELLO',
-        example_location:   RSpec.current_example.location,
-        error_raised:       false,
-        in_ambiguous_raise: false
+        scope:                     :class,
+        selector:                  :singleton_method_example,
+        namespace:                 Foo.singleton_class,
+        params:                    { baz: 'Hello' },
+        return_value:              'HELLO',
+        example_location:          RSpec.current_example.location,
+        error_raised:              false,
+        in_ambiguous_raise:        false,
+        in_ambiguous_block_return: false
       ),
       Yardcheck::MethodCall.process(
-        scope:              :instance,
-        selector:           :instance_method_example,
-        namespace:          Foo,
-        params:             { baz: 'Hello' },
-        return_value:       'HELLO',
-        example_location:   RSpec.current_example.location,
-        error_raised:       false,
-        in_ambiguous_raise: false
+        scope:                     :instance,
+        selector:                  :instance_method_example,
+        namespace:                 Foo,
+        params:                    { baz: 'Hello' },
+        return_value:              'HELLO',
+        example_location:          RSpec.current_example.location,
+        error_raised:              false,
+        in_ambiguous_raise:        false,
+        in_ambiguous_block_return: false
       )
     ])
   end

--- a/spec/unit/yardcheck/runner_spec.rb
+++ b/spec/unit/yardcheck/runner_spec.rb
@@ -20,24 +20,26 @@ RSpec.describe Yardcheck::Runner do
   let(:observed_events) do
     [
       Yardcheck::MethodCall.process(
-        scope:              :instance,
-        selector:           :add,
-        namespace:          TestApp::Namespace,
-        params:             { left: 'foo', right: 3 },
-        return_value:       5,
-        example_location:   'test_app_spec.rb:1',
-        error_raised:       false,
-        in_ambiguous_raise: false
+        scope:                     :instance,
+        selector:                  :add,
+        namespace:                 TestApp::Namespace,
+        params:                    { left: 'foo', right: 3 },
+        return_value:              5,
+        example_location:          'test_app_spec.rb:1',
+        error_raised:              false,
+        in_ambiguous_raise:        false,
+        in_ambiguous_block_return: false
       ),
       Yardcheck::MethodCall.process(
-        scope:              :class,
-        selector:           :add,
-        namespace:          TestApp::Namespace.singleton_class,
-        params:             { left: 2, right: 3 },
-        return_value:       5,
-        example_location:   'test_app_spec.rb:2',
-        error_raised:       false,
-        in_ambiguous_raise: false
+        scope:                     :class,
+        selector:                  :add,
+        namespace:                 TestApp::Namespace.singleton_class,
+        params:                    { left: 2, right: 3 },
+        return_value:              5,
+        example_location:          'test_app_spec.rb:2',
+        error_raised:              false,
+        in_ambiguous_raise:        false,
+        in_ambiguous_block_return: false
       )
     ]
   end
@@ -46,7 +48,7 @@ RSpec.describe Yardcheck::Runner do
     <<~MSG
       Expected #<Class:TestApp::Namespace>#add to return String but observed Fixnum
 
-          source: ./test_app/lib/test_app.rb:13
+          source: ./test_app/lib/test_app.rb:14
           tests:
             - test_app_spec.rb:2
 
@@ -62,7 +64,7 @@ RSpec.describe Yardcheck::Runner do
 
       Expected TestApp::Namespace#add to receive Integer for left but observed String
 
-          source: ./test_app/lib/test_app.rb:23
+          source: ./test_app/lib/test_app.rb:24
           tests:
             - test_app_spec.rb:1
 
@@ -78,7 +80,7 @@ RSpec.describe Yardcheck::Runner do
 
       Expected TestApp::Namespace#add to return String but observed Fixnum
 
-          source: ./test_app/lib/test_app.rb:23
+          source: ./test_app/lib/test_app.rb:24
           tests:
             - test_app_spec.rb:1
 
@@ -113,34 +115,37 @@ RSpec.describe Yardcheck::Runner do
     let(:observed_events) do
       [
         Yardcheck::MethodCall.process(
-          scope:              :instance,
-          selector:           :add,
-          namespace:          TestApp::Namespace,
-          params:             { left: 'foo', right: 3 },
-          return_value:       'valid return type',
-          example_location:   'test_app_spec.rb:1',
-          error_raised:       false,
-          in_ambiguous_raise: false
+          scope:                     :instance,
+          selector:                  :add,
+          namespace:                 TestApp::Namespace,
+          params:                    { left: 'foo', right: 3 },
+          return_value:              'valid return type',
+          example_location:          'test_app_spec.rb:1',
+          error_raised:              false,
+          in_ambiguous_raise:        false,
+          in_ambiguous_block_return: false
         ),
         Yardcheck::MethodCall.process(
-          scope:              :instance,
-          selector:           :add,
-          namespace:          TestApp::Namespace,
-          params:             { left: 'foo', right: 3 },
-          return_value:       'valid return type',
-          example_location:   'test_app_spec.rb:2',
-          error_raised:       false,
-          in_ambiguous_raise: false
+          scope:                     :instance,
+          selector:                  :add,
+          namespace:                 TestApp::Namespace,
+          params:                    { left: 'foo', right: 3 },
+          return_value:              'valid return type',
+          example_location:          'test_app_spec.rb:2',
+          error_raised:              false,
+          in_ambiguous_raise:        false,
+          in_ambiguous_block_return: false
         ),
         Yardcheck::MethodCall.process(
-          scope:              :instance,
-          selector:           :add,
-          namespace:          TestApp::Namespace,
-          params:             { left: 1, right: 'now this one is wrong' },
-          return_value:       'valid return type',
-          example_location:   'test_app_spec.rb:3',
-          error_raised:       false,
-          in_ambiguous_raise: false
+          scope:                     :instance,
+          selector:                  :add,
+          namespace:                 TestApp::Namespace,
+          params:                    { left: 1, right: 'now this one is wrong' },
+          return_value:              'valid return type',
+          example_location:          'test_app_spec.rb:3',
+          error_raised:              false,
+          in_ambiguous_raise:        false,
+          in_ambiguous_block_return: false
         )
       ]
     end
@@ -149,7 +154,7 @@ RSpec.describe Yardcheck::Runner do
       <<~MSG
         Expected TestApp::Namespace#add to receive Integer for left but observed String
 
-            source: ./test_app/lib/test_app.rb:23
+            source: ./test_app/lib/test_app.rb:24
             tests:
               - test_app_spec.rb:1
               - test_app_spec.rb:2
@@ -166,7 +171,7 @@ RSpec.describe Yardcheck::Runner do
 
         Expected TestApp::Namespace#add to receive Integer for right but observed String
 
-            source: ./test_app/lib/test_app.rb:23
+            source: ./test_app/lib/test_app.rb:24
             tests:
               - test_app_spec.rb:3
 

--- a/test_app/lib/test_app.rb
+++ b/test_app/lib/test_app.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_app/ambiguous_raise'
+require 'test_app/block_return'
 
 module TestApp
   class Namespace

--- a/test_app/lib/test_app/block_return.rb
+++ b/test_app/lib/test_app/block_return.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module TestApp
+  module BlockReturn
+    SomeError = Class.new(StandardError)
+
+    # @return [Integer]
+    def self.entrypoint
+      method_that_executes_normal_block do
+        1
+      end
+
+      method_that_passes_block_with_return_keyword_along do
+        return 1
+      end
+
+      'foo'
+    end
+
+    # @return [Integer]
+    def self.method_that_passes_block_with_return_keyword_along(&block)
+      method_that_yield_block_with_return_keyword(&block)
+
+      2
+    end
+
+    # @return [Integer]
+    def self.method_that_yield_block_with_return_keyword
+      yield
+
+      3
+    end
+
+    def self.method_that_executes_normal_block
+      yield
+
+      4
+    end
+  end
+end

--- a/test_app/spec/test_app/block_return_spec.rb
+++ b/test_app/spec/test_app/block_return_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative './../../lib/test_app'
+
+RSpec.describe TestApp::BlockReturn do
+  it 'calls a method which eventually yields and then executes a return' do
+    expect(described_class.entrypoint).to be(1)
+  end
+end


### PR DESCRIPTION
A block containing a `return` keyword can cause return events to
report invalid return values. Consider the example below

    class Foo
      # @return [Integer]
      def bar
        baz { return 1 }
      end

      # @return [Symbol]
      def norf
        baz
      end

      private

      # @return [Symbol]
      def baz(&block)
        qux(&block) if block_given?

        :baz
      end

      # @return [Symbol]
      def qux
        yield if block_given?

        :qux
      end
    end

    Foo.new.bar  # => 1
    Foo.new.norf # => :baz

When you call `bar` you pass a block down through `baz` and `qux`. The
block is executed inside of `qux` via the `yield`. Since the original
block inside of the `bar` method contains a `return`, this `yield`
results in `qux` and `baz` terminating. According to `TracePoint`, these
methods are "returning" with the value `nil` but this return value is
impossible to actually use. Therefore, we track when a `b_return` event
occurs and flag the tracing state as ambiguous until this is resolved.