### PR TITLE
Special case Hash and Array

### DIFF
--- a/lib/yardcheck/const.rb
+++ b/lib/yardcheck/const.rb
@@ -4,8 +4,13 @@ module Yardcheck
   class Const
     include Concord::Public.new(:constant)
 
+    SPECIAL_CASES = [
+      Hash,
+      Array
+    ].map { |const| [const.name, const] }.to_h
+
     def self.resolve(constant_name, scope = Object)
-      return new(scope.const_get(constant_name)) if scope.const_defined?(constant_name)
+      return new(const_lookup(scope, constant_name)) if scope.const_defined?(constant_name)
 
       parent = parent_namespace(scope)
       from_parent = resolve(constant_name, parent.constant) if parent.valid?
@@ -21,6 +26,13 @@ module Yardcheck
         resolve(parent_name)
       end
     end
+
+    def self.const_lookup(scope, name)
+      SPECIAL_CASES.fetch(name) do
+        scope.const_get(name) if scope.const_defined?(name)
+      end
+    end
+    private_class_method :const_lookup
 
     def valid?
       true

--- a/spec/unit/yardcheck/const_spec.rb
+++ b/spec/unit/yardcheck/const_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Yardcheck::Const do
       module Bar
         module Baz
         end # Baz
+
+        class Hash
+        end # Hash
       end # Bar
     end # Foo
   end
@@ -44,5 +47,12 @@ RSpec.describe Yardcheck::Const do
     expect(described_class.resolve('What', Foo::Bar)).to eql(
       described_class::Invalid.new(Foo::Bar, 'What')
     )
+  end
+
+  it 'special cases Hash' do
+    aggregate_failures do
+      expect(described_class.resolve('Hash', Foo::Bar)).to eql(described_class.new(Hash))
+      expect(described_class.resolve('Bar::Hash', Foo)).to eql(described_class.new(Foo::Bar::Hash))
+    end
   end
 end

--- a/test_app/lib/test_app.rb
+++ b/test_app/lib/test_app.rb
@@ -124,6 +124,17 @@ module TestApp
       1
     end
 
+    # @return [Array<Hash>]
+    def special_cases_top_level_constants
+      [{}]
+    end
+
+    class Hash
+    end
+
+    class Array
+    end
+
     class Parent
     end
 

--- a/test_app/spec/test_app_spec.rb
+++ b/test_app/spec/test_app_spec.rb
@@ -56,4 +56,8 @@ RSpec.describe TestApp::Namespace do
   specify do
     expect(object.tags_without_types(1)).to be(nil)
   end
+
+  it 'special cases Array and Hash' do
+    expect(object.special_cases_top_level_constants).to eq([{}])
+  end
 end


### PR DESCRIPTION
YARD parses the following as `Hash` and `Array`:

    # @return Array<Foo>
    # @return <Foo>
    # @return Hash{Foo => Bar}
    # @return {Foo => Bar}

as `Array` and `Hash`. I think people should have to qualify their
inner namespace if they want to specify something like Dry::Types::Hash.

Fixes #3