### PR TITLE
Represent different method exits

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -212,3 +212,5 @@ Lint/DefEndAlignment:
 # See explanation for `Lint/DefEndAlignment`
 Lint/EndAlignment:
   AutoCorrect: true
+Style/MixinGrouping:
+  EnforcedStyle: grouped

--- a/lib/yardcheck/method_tracer.rb
+++ b/lib/yardcheck/method_tracer.rb
@@ -8,15 +8,15 @@ module Yardcheck
       super(namespace, [], [])
 
       # When an exception is raised it isn't clear when it has been eventually rescued.
-      # We set `@ambiguous_exception_state` to `true` when we have observed an exception
+      # We set `@current_exception` to `true` when we have observed an exception
       # and have not seen a non `nil` return.
-      @ambiguous_exception_state = false
+      @current_exception = nil
 
       # A block passed from one method down to another method can trigger a return of the
       # originating method. This triggers a waterfall of `nil` returns because each method
-      # shortcircuits. Similar to `ambiguous_exception_state` we need to also track ambiguous
-      # block return state.
-      @ambiguous_block_return_state = false
+      # shortcircuits. Similar to `current_exception` we need to also track jumps triggered
+      # by block returns
+      @block_jump = false
     end
 
     def trace(&block)
@@ -29,7 +29,7 @@ module Yardcheck
 
     private
 
-    attr_reader :ambiguous_exception_state, :ambiguous_block_return_state
+    attr_reader :current_exception, :block_jump
 
     def tracer
       TracePoint.new(:call, :return, :raise, :b_return) do |event|
@@ -44,7 +44,7 @@ module Yardcheck
       case trace_event.event
       when :call     then process_call(trace_event)
       when :return   then process_return(trace_event)
-      when :raise    then process_raise
+      when :raise    then process_raise(trace_event)
       when :b_return then process_block_return
       end
     end
@@ -52,7 +52,7 @@ module Yardcheck
     def process_call(trace_event)
       # If we observe a method call then we are certainly no longer inside of a
       # bubbling up of early returns
-      @ambiguous_block_return_state = false
+      @block_jump = false
 
       parameter_names =
         trace_event
@@ -78,26 +78,29 @@ module Yardcheck
       # "fake returns" caused by either an exception being raised or a block being executed
       # that invoked `return` and caused other methods to return early
       unless nil.equal?(return_value)
-        @ambiguous_exception_state    = false
-        @ambiguous_block_return_state = false
+        @current_exception = nil
+        @block_jump        = false
       end
 
-      seen << MethodCall.process(
-        call_stack.pop.merge(
-          return_value:              trace_event.return_value,
-          in_ambiguous_raise:        ambiguous_exception_state,
-          in_ambiguous_block_return: ambiguous_block_return_state
-        )
-      )
+      frame = call_stack.pop
+      method_call =
+        if @current_exception
+          MethodCall::Raise.process(frame.merge(exception: @current_exception))
+        elsif @block_jump
+          MethodCall::Jump.process(frame)
+        else
+          MethodCall::Return.process(frame.merge(return_value: return_value))
+        end
+
+      seen << method_call
     end
 
-    def process_raise
-      call_stack.last[:error_raised] = true
-      @ambiguous_exception_state = true
+    def process_raise(trace_event)
+      @current_exception = trace_event.raised_exception
     end
 
     def process_block_return
-      @ambiguous_block_return_state = true
+      @block_jump = true
     end
 
     def event_details(event)
@@ -105,8 +108,7 @@ module Yardcheck
         scope:            event.defined_class.__send__(:singleton_class?) ? :class : :instance,
         selector:         event.method_id,
         namespace:        event.defined_class,
-        example_location: RSpec.current_example.location,
-        error_raised:     false
+        example_location: RSpec.current_example.location
       }
     end
 

--- a/lib/yardcheck/observation.rb
+++ b/lib/yardcheck/observation.rb
@@ -62,13 +62,12 @@ module Yardcheck
       valid_return? ? [Violation::Return.new(self)] : []
     end
 
-    def valid_return? # rubocop:disable AbcSize
-      documentation.return_type &&
+    def valid_return?
+      documentation.return_type                               &&
+        event.return?                                         &&
         !documentation.return_type.match?(event.return_value) &&
-        !event.raised? &&
-        !event.initialize? &&
-        !documentation.predicate_method? &&
-        !event.ambiguous_return_state? &&
+        !event.initialize?                                    &&
+        !documentation.predicate_method?                      &&
         !possible_tracepoint_bug?
     end
 

--- a/lib/yardcheck/processed_source.rb
+++ b/lib/yardcheck/processed_source.rb
@@ -2,8 +2,7 @@
 
 module Yardcheck
   class ProcessedSource
-    include Concord.new(:raw_source)
-    include Adamantium::Flat
+    include Concord.new(:raw_source), Adamantium::Flat
 
     # @see https://bugs.ruby-lang.org/issues/13369
     def tracepoint_bug_candidate?

--- a/spec/unit/yardcheck/method_tracer_spec.rb
+++ b/spec/unit/yardcheck/method_tracer_spec.rb
@@ -36,27 +36,21 @@ RSpec.describe Yardcheck::MethodTracer do
     end
 
     expect(tracer.events).to eq([
-      Yardcheck::MethodCall.process(
-        scope:                     :class,
-        selector:                  :singleton_method_example,
-        namespace:                 Foo.singleton_class,
-        params:                    { baz: 'Hello' },
-        return_value:              'HELLO',
-        example_location:          RSpec.current_example.location,
-        error_raised:              false,
-        in_ambiguous_raise:        false,
-        in_ambiguous_block_return: false
+      Yardcheck::MethodCall::Return.process(
+        scope:            :class,
+        selector:         :singleton_method_example,
+        namespace:        Foo.singleton_class,
+        params:           { baz: 'Hello' },
+        return_value:     'HELLO',
+        example_location: RSpec.current_example.location
       ),
-      Yardcheck::MethodCall.process(
-        scope:                     :instance,
-        selector:                  :instance_method_example,
-        namespace:                 Foo,
-        params:                    { baz: 'Hello' },
-        return_value:              'HELLO',
-        example_location:          RSpec.current_example.location,
-        error_raised:              false,
-        in_ambiguous_raise:        false,
-        in_ambiguous_block_return: false
+      Yardcheck::MethodCall::Return.process(
+        scope:            :instance,
+        selector:         :instance_method_example,
+        namespace:        Foo,
+        params:           { baz: 'Hello' },
+        return_value:     'HELLO',
+        example_location: RSpec.current_example.location
       )
     ])
   end

--- a/spec/unit/yardcheck/runner_spec.rb
+++ b/spec/unit/yardcheck/runner_spec.rb
@@ -19,27 +19,21 @@ RSpec.describe Yardcheck::Runner do
 
   let(:observed_events) do
     [
-      Yardcheck::MethodCall.process(
-        scope:                     :instance,
-        selector:                  :add,
-        namespace:                 TestApp::Namespace,
-        params:                    { left: 'foo', right: 3 },
-        return_value:              5,
-        example_location:          'test_app_spec.rb:1',
-        error_raised:              false,
-        in_ambiguous_raise:        false,
-        in_ambiguous_block_return: false
+      Yardcheck::MethodCall::Return.process(
+        scope:            :instance,
+        selector:         :add,
+        namespace:        TestApp::Namespace,
+        params:           { left: 'foo', right: 3 },
+        return_value:     5,
+        example_location: 'test_app_spec.rb:1'
       ),
-      Yardcheck::MethodCall.process(
-        scope:                     :class,
-        selector:                  :add,
-        namespace:                 TestApp::Namespace.singleton_class,
-        params:                    { left: 2, right: 3 },
-        return_value:              5,
-        example_location:          'test_app_spec.rb:2',
-        error_raised:              false,
-        in_ambiguous_raise:        false,
-        in_ambiguous_block_return: false
+      Yardcheck::MethodCall::Return.process(
+        scope:            :class,
+        selector:         :add,
+        namespace:        TestApp::Namespace.singleton_class,
+        params:           { left: 2, right: 3 },
+        return_value:     5,
+        example_location: 'test_app_spec.rb:2'
       )
     ]
   end
@@ -114,38 +108,29 @@ RSpec.describe Yardcheck::Runner do
   context 'when multiple tests find the same violation' do
     let(:observed_events) do
       [
-        Yardcheck::MethodCall.process(
-          scope:                     :instance,
-          selector:                  :add,
-          namespace:                 TestApp::Namespace,
-          params:                    { left: 'foo', right: 3 },
-          return_value:              'valid return type',
-          example_location:          'test_app_spec.rb:1',
-          error_raised:              false,
-          in_ambiguous_raise:        false,
-          in_ambiguous_block_return: false
+        Yardcheck::MethodCall::Return.process(
+          scope:            :instance,
+          selector:         :add,
+          namespace:        TestApp::Namespace,
+          params:           { left: 'foo', right: 3 },
+          return_value:     'valid return type',
+          example_location: 'test_app_spec.rb:1'
         ),
-        Yardcheck::MethodCall.process(
-          scope:                     :instance,
-          selector:                  :add,
-          namespace:                 TestApp::Namespace,
-          params:                    { left: 'foo', right: 3 },
-          return_value:              'valid return type',
-          example_location:          'test_app_spec.rb:2',
-          error_raised:              false,
-          in_ambiguous_raise:        false,
-          in_ambiguous_block_return: false
+        Yardcheck::MethodCall::Return.process(
+          scope:            :instance,
+          selector:         :add,
+          namespace:        TestApp::Namespace,
+          params:           { left: 'foo', right: 3 },
+          return_value:     'valid return type',
+          example_location: 'test_app_spec.rb:2'
         ),
-        Yardcheck::MethodCall.process(
-          scope:                     :instance,
-          selector:                  :add,
-          namespace:                 TestApp::Namespace,
-          params:                    { left: 1, right: 'now this one is wrong' },
-          return_value:              'valid return type',
-          example_location:          'test_app_spec.rb:3',
-          error_raised:              false,
-          in_ambiguous_raise:        false,
-          in_ambiguous_block_return: false
+        Yardcheck::MethodCall::Return.process(
+          scope:            :instance,
+          selector:         :add,
+          namespace:        TestApp::Namespace,
+          params:           { left: 1, right: 'now this one is wrong' },
+          return_value:     'valid return type',
+          example_location: 'test_app_spec.rb:3'
         )
       ]
     end


### PR DESCRIPTION
Previously the method tracer tracked "ambiguous return state" where
either an exception is being raised or a block returned and is early
exiting methods. This refactor changes the terminology a bit and adds
different `MethodCall` exit representations:

  - `MethodCall::Return` a normal method call where the value returned
    means something

  - `MethodCall::Raise` a method call that exited because an exception
    was raised and ended the method execution

  - `MethodCall:Jump` a method call that exited after a block provided
    higher up the stack was yielded to and called `return`

These abstractions better represent what is going on and they also
establish some groundwork for implementing #21.